### PR TITLE
旅ガイドページ一覧にタイトル検索機能を作る #24

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -3,7 +3,11 @@ class GuidesController < ApplicationController
   before_action :set_guide, only: [:show, :edit, :update, :destroy]
 
   def index
-    @guides = Guide.all
+    if params[:search]
+      @guides = Guide.where("title LIKE ?", "%#{params[:search_title]}%")
+    else
+      @guides = Guide.all
+    end
   end
 
   def new

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -1,3 +1,11 @@
+<div class="search_box" >
+  <%= form_with(local: true, method: :get, url: guides_path ) do |form| %>
+    <%= form.label :search_title, I18n.t('views.messages.search_title') %>
+    <%= form.text_field :search_title, placeholder: I18n.t('views.messages.search_by_title') %>
+    <%= form.submit I18n.t('views.messages.search'), name: "search" %>
+  <% end %>
+</div>
+
 <% if user_signed_in? %>
   <p><%= link_to I18n.t('views.messages.new_guide'), new_guide_path %></p>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -227,3 +227,6 @@ ja:
       edit_user: 'ユーザー情報編集'
       delete_user: 'ユーザー情報削除'
       back_usershow: 'ユーザーページに戻る'
+      search_title: 'タイトル検索'
+      search_by_title: 'タイトルで検索する'
+      search: '検索'

--- a/db/migrate/20210607113837_add_index_to_guides_title.rb
+++ b/db/migrate/20210607113837_add_index_to_guides_title.rb
@@ -1,0 +1,5 @@
+class AddIndexToGuidesTitle < ActiveRecord::Migration[5.2]
+  def change
+    add_index :guides, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_102125) do
+ActiveRecord::Schema.define(version: 2021_06_07_113837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_102125) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_guides_on_title"
     t.index ["user_id"], name: "index_guides_on_user_id"
   end
 


### PR DESCRIPTION
- ガイドビュー　一覧画面にタイトル検索フォームを実装
- ガイドビュー　一覧画面 タイトル検索フォームの各文言を国際化
- ガイドコントローラーのindexアクションでタイトル検索を実行する
- ガイドモデル タイトルカラムに検索インデックスを貼る