### PR TITLE
旅ガイドページ一覧に都道府県検索機能を作る #26

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -4,9 +4,17 @@ class GuidesController < ApplicationController
 
   def index
     if params[:search]
-      @guides = Guide.where("title LIKE ?", "%#{params[:search_title]}%")
+      if params[:search_title].present? && params[:search_prefecture].present?
+        @guides = Guide.search_title(params[:search_title]).search_prefecture(params[:search_prefecture])
+      elsif params[:search_title].present?
+        @guides = Guide.search_title(params[:search_title])
+      elsif params[:search_prefecture].present?
+        @guides = Guide.search_prefecture(params[:search_prefecture])
+      else
+        @guides = Guide.order(created_at: :desc)
+      end
     else
-      @guides = Guide.all
+      @guides = Guide.order(created_at: :desc)
     end
   end
 

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -18,4 +18,7 @@ class Guide < ApplicationRecord
     福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,
     沖縄県:47
    }
+
+   scope :search_title, -> (search_title) { where("title LIKE ?", "%#{search_title}%") }
+   scope :search_prefecture, -> (search_prefecture) { where(prefecture: search_prefecture)}
 end

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -2,6 +2,8 @@
   <%= form_with(local: true, method: :get, url: guides_path ) do |form| %>
     <%= form.label :search_title, I18n.t('views.messages.search_title') %>
     <%= form.text_field :search_title, placeholder: I18n.t('views.messages.search_by_title') %>
+    <%= form.label :search_prefecture, I18n.t('views.messages.search_prefectures') %>
+    <%= form.select :search_prefecture, Guide.prefectures.keys, { include_blank: I18n.t('views.messages.please_selected') } %>
     <%= form.submit I18n.t('views.messages.search'), name: "search" %>
   <% end %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -230,3 +230,5 @@ ja:
       search_title: 'タイトル検索'
       search_by_title: 'タイトルで検索する'
       search: '検索'
+      search_prefectures: '都道府県検索'
+      please_selected: '選択してください'


### PR DESCRIPTION
- ガイドビュー　一覧画面に都道府県検索フォームを実装
- ガイドビュー　一覧画面 都道府県検索フォームの各文言を国際化
- ガイドコントローラーのindexアクションでタイトルと都道府県の両方で検索を実行する
- タイトル・都道府県の検索ロジックをガイドモデルに作成する