### PR TITLE
お気に入り機能を作る #30 (2)

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,7 +2,7 @@ class FavoritesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @favorites = current_user.favorites.all
+    @favorites = current_user.favorites.all.page(params[:page]).per(5)
   end
 
   def create

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -28,5 +28,9 @@
 <% end %>
 </ul>
 
+<div class="pagination_block">
+  <%= paginate @favorites %>
+</div>
+
 <%= link_to I18n.t('views.messages.back_index'), guides_path %>
 <%= link_to I18n.t('views.messages.back_usershow'), user_path(current_user.id) %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,32 @@
+<h2>お気に入りしたページ一覧</h2>
+
+<ul>
+<% if @favorites.size != 0 %>
+  <% @favorites.each do |favorite| %>
+    <li class="flex">
+      <p class="img item">
+        <% main_flag_picture = favorite.guide.pictures.find { |picture| picture[:main_flag] == true} %>
+        <% if main_flag_picture[:image] != nil %>
+          <%= image_tag main_flag_picture.image.url %>
+        <% else %>
+          まだメイン画像が登録されていません
+        <% end %>
+      </p>
+      <div class="left item">
+        <p class="title"><%= favorite.guide.title %></p>
+        <p class="data_group">
+          <span class="name">ユーザー名:<%= favorite.guide.user.name %></span>
+          <span class="prefecture">都道府県:<%= favorite.guide.prefecture %></span>
+          <span class="favorite_count">お気に入り数:<%= favorite.guide.favorites.count %></span>
+        </p>
+        <p class="show_btn"><%= link_to I18n.t('views.messages.show'), guide_path(favorite.guide.id) %></p>
+      </div>
+    </li>
+  <% end %>
+<% else %>
+  <li><p>お気に入り登録はまだありません。</p></li>
+<% end %>
+</ul>
+
+<%= link_to I18n.t('views.messages.back_index'), guides_path %>
+<%= link_to I18n.t('views.messages.back_usershow'), user_path(current_user.id) %>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -28,6 +28,7 @@
       <p class="data_group">
         <span class="name">ユーザー名:<%= guide.user.name %></span>
         <span class="prefecture">都道府県:<%= guide.prefecture %></span>
+        <span class="favorite_count">お気に入り数:<%= guide.favorites.count %></span>
       </p>
       <p class="show_btn"><%= link_to I18n.t('views.messages.show'), guide_path(guide.id) %></p>
     </div>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -13,7 +13,14 @@
   <div class="item right">
     <p class="data_group">
       <span class="name">ユーザー名:<%= @guide.user.name %></span>
-      <%= link_to I18n.t('views.messages.show'), user_path(@guide.user.id) %>
+      <span class="favorite_count">お気に入り数:<%= @guide.favorites.count %></span>
+      <% if user_signed_in? && @guide.user.id != current_user.id %>
+        <% if @favorite.present? %>
+          <%= link_to I18n.t('views.messages.do_favorite_deletion'), favorite_path(id: @favorite.id), method: :delete %>
+        <% else %>
+          <%= link_to I18n.t('views.messages.do_favorite_register'), favorites_path(guide_id: @guide.id), method: :post %>
+        <% end %>
+      <% end %>
     </p>
     <p class="title"><%= @guide.title %></p>
     <div class="location">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,6 +28,13 @@
         <th>メールアドレス</th>
         <td><%= @user.email %></td>
       </tr>
+      <tr>
+        <th>お気に入りページ</th>
+        <td>
+          <span class="favorite_count"><%= @user.favorites.count %>件</span>
+          <%= link_to I18n.t('views.messages.go_favorites_index'), favorites_path %>
+        </td>
+      </tr>
       <% end %>
     </table>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -236,3 +236,4 @@ ja:
       delete_favorite: 'お気に入り削除しました'
       do_favorite_register: 'お気に入り登録する'
       do_favorite_deletion: 'お気に入り削除する'
+      go_favorites_index: 'お気に入り一覧を見る'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -234,3 +234,5 @@ ja:
       please_selected: '選択してください'
       register_favorite: 'お気に入り登録しました！'
       delete_favorite: 'お気に入り削除しました'
+      do_favorite_register: 'お気に入り登録する'
+      do_favorite_deletion: 'お気に入り削除する'


### PR DESCRIPTION
- ガイドビュー　詳細ページにお気に入り数とお気に入り追加リンクを設置
- ガイドビュー　詳細ページのお気に入り数とお気に入り登録・削除リンクの文言を国際化
- ガイドビュー　一覧ページにお気に入り数表記を設置
- お気に入り機能　一覧ページを作成
- ユーザービュー　詳細画面にお気に入り件数とお気に入り一覧ページへのリンクを設置
- ユーザービュー　詳細画面 お気に入り一覧ページへのリンクの文言を国際化
- お気に入り機能のコントローラーにページネーション機能を実装
- お気に入り機能　一覧ページにページネーション表示パーツを実装