### PR TITLE
管理者機能を作る #40 (1)

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,2 @@
+class Admin::UsersController < ApplicationController
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,2 +1,55 @@
 class Admin::UsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :if_not_admin
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @users = User.select(:id, :name, :image).order(created_at: :asc).page(params[:page]).per(5)
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+    else
+      render :edit
+    end
+  end
+
+  def show
+  end
+
+  def destroy
+    if @user.destroy
+      redirect_to admin_users_path, notice: I18n.t('views.messages.destroy_user')
+    else
+      redirect_to admin_users_path, notice: I18n.t('views.messages.cannot_destroy_user')
+    end
+  end
+
+  private
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :self_introduction, :image, :image_cache)
+  end
+
+  def if_not_admin
+    redirect_to guides_path, notice: I18n.t('views.messages.cannot_access_admin') unless admin?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,10 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
+    if current_user.admin?
+      admin_users_path
+    else
      guides_path
+    end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :require_no_authentication, only: [:cancel]
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
@@ -38,8 +39,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
+  def current_user_is_admin?
+    user_signed_in? && current_user.admin?
+  end
+
+  def sign_up(resource_name, resource)
+    if !current_user_is_admin?
+      sign_in(resource_name, resource)
+    end
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,11 @@ class UsersController < ApplicationController
   def update
     if @user.update(user_edit_params)
       sign_in(@user, bypass: true) if current_user.id == @user.id
-      redirect_to user_path(@user.id), notice: I18n.t('views.messages.update_user')
+      if current_user.admin?
+        redirect_to admin_users_path, notice: I18n.t('views.messages.update_user')
+      else
+        redirect_to user_path(@user.id), notice: I18n.t('views.messages.update_user')
+      end
     else
       render :edit
     end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -240,3 +240,5 @@ ja:
       follow: 'フォローする'
       unfollow: 'フォロー解除'
       go_following_index: 'フォロー一覧を見る'
+      cannot_destroy_user: '管理者は削除できません。'
+      cannot_access_admin: '管理画面へは、管理者以外はアクセスできません'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
   resources :users
+  namespace :admin do
+   resources :users
+  end
   resources :favorites, only: [:index, :create, :destroy]
   resources :relationships, only: [:index, :create, :destroy]
 end

--- a/db/migrate/20210607134050_add_admin_to_users.rb
+++ b/db/migrate/20210607134050_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_131226) do
+ActiveRecord::Schema.define(version: 2021_06_07_134050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_131226) do
     t.text "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- ユーザーテーブルにboolean型のadminカラムを追加
- 1ユーザーに管理者権限をつける
- 管理画面のルーティングを設定
- 管理者コントローラーを生成
- 管理者コントローラーに各種アクションを設定
- 管理者コントローラーのflashメッセージを国際化
- deviseコントローラー　ユーザー登録をサインイン済みでもユーザー登録ができるようカスタマイズ
- 管理者のsign_in後のpathを指定
- ユーザーコントローラー　更新後の管理者用のリダイレクトパスを記述