### PR TITLE
管理者機能を作る #40 (2)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  include UsersHelper
 
   protected
   def configure_permitted_parameters

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,7 @@
+module UsersHelper
+  def admin?
+    if user_signed_in?
+      current_user.admin?
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,12 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+   before_destroy :ensure_has_admin
+   private
+   def ensure_has_admin
+     if User.where(admin: true).count == 1 && self.admin?
+       throw(:abort)
+     end
+   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,72 @@
+<%= form_with(model: @user, local: true) do |form| %>
+  <% if @user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= @user.errors.count %>件のエラーがあります。</h2>
+      <ul>
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <section id="fields">
+    <table>
+      <tr>
+        <th>
+          <%= form.label :name %>
+        </th>
+        <td>
+          <%= form.text_field :name %>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          <%= form.label :self_introduction %>
+        </th>
+        <td>
+          <%= form.text_area :self_introduction %>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          <%= form.label :email %>
+        </th>
+        <td>
+          <%= form.email_field :email %>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          <%= form.label :image %>
+        </th>
+        <td>
+          <%= image_tag(@user.image.url) if @user.image && @user.image.url %>
+          <%= form.file_field :image %>
+          <%= form.hidden_field :image_cache %>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          <%= form.label :password %>
+        </th>
+        <td>
+          <%= form.password_field :password %>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          <%= form.label :password_confirmation %>
+        </th>
+        <td>
+          <%= form.password_field :password_confirmation %>
+        </td>
+      </tr>
+    </table>
+  </section>
+
+  <div class="actions">
+    <%= form.submit data: { confirm: I18n.t('views.messages.confirm_submit') } %>
+  </div>
+
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,5 @@
+<h2>管理画面：ユーザー情報編集</h2>
+<%= render 'form' %>
+
+<%= link_to I18n.t('views.messages.back_index'), guides_path %>
+<%= link_to I18n.t('views.messages.back_admin_index'), admin_users_path %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,35 @@
+<h2>管理画面：ユーザー一覧</h2>
+
+<ul>
+  <% @users.each do |user| %>
+    <li>
+      <p class="img">
+        <% if user.image.url != nil %>
+        <%= image_tag user.image.url %>
+        <% else %>
+        まだ登録はありません
+        <% end %>
+      </p>
+      <p class="name">
+        <%= user.name %>さん
+        <% if user == current_user %>
+          <span class="admin">管理者</span>
+        <% end %>
+      </p>
+      <p class="btn_group">
+        <%= link_to I18n.t('views.messages.show'), user_path(user.id) %>
+        <%= link_to I18n.t('views.messages.edit_user'), edit_admin_user_path(user.id), data: { confirm: I18n.t('views.messages.confirm_edit') } %>
+        <% if user != current_user %>
+          <%= link_to I18n.t('views.messages.delete_user'), admin_user_path(user.id), method: :delete ,data: { confirm: I18n.t('views.messages.confirm_delete') } %>
+        <% end %>
+      </p>
+    </li>
+  <% end %>
+</ul>
+
+<div class="pagination_block">
+  <%= paginate @users %>
+</div>
+
+<%= link_to I18n.t('views.messages.back_index'), guides_path %>
+<%= link_to I18n.t('views.messages.new_registration'), new_admin_user_path %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h2>管理画面：新規ユーザー登録</h2>
+<%= render 'form' %>
+
+<%= link_to I18n.t('views.messages.back_index'), guides_path %>
+<%= link_to I18n.t('views.messages.back_admin_index'), admin_users_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>Tabishinan</title>
     <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=2.0,user-scalable=yes">
-    
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -13,6 +13,9 @@
 
   <body>
     <% if user_signed_in? %>
+      <% if admin? %>
+        <%= link_to I18n.t('views.messages.admin_index'), admin_users_path %>
+      <% end %>
       <%= link_to I18n.t('views.messages.my_page'), user_path(current_user.id) %>
       <%= link_to I18n.t('views.messages.logout'), destroy_user_session_path, method: :delete %>
     <% else %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -242,3 +242,5 @@ ja:
       go_following_index: 'フォロー一覧を見る'
       cannot_destroy_user: '管理者は削除できません。'
       cannot_access_admin: '管理画面へは、管理者以外はアクセスできません'
+      admin_index: '管理画面'
+      back_admin_index: '管理画面へ戻る'


### PR DESCRIPTION
- 管理画面ビュー　一覧画面を作成
- 管理画面ビュー　新規ユーザー登録画面を作成
- 管理画面ビュー　ユーザー新規登録画面のリンクの文言を国際化
- 管理画面ビュー　ユーザー編集画面を作成
- 管理画面ビュー　パーシャル フォームページ作成
- ユーザーモデルに管理ユーザーの削除を防ぐメソッドを記述
- 共通レイアウト部分に、管理者にだけ管理画面のリンクを表示