### PR TITLE
管理者ゲストログイン機能を作成 #51

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,6 +9,13 @@ class Users::SessionsController < Devise::SessionsController
     redirect_to guides_path, notice: I18n.t('views.messages.logged_in_as_guest_user')
   end
 
+  def admin_guest_sign_in
+    user = User.admin_guest
+    sign_in user
+    user.admin = true
+    redirect_to admin_users_path, notice: I18n.t('views.messages.logged_in_as_admin_guest_user')
+  end
+
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,13 @@ class User < ApplicationRecord
     end
   end
 
+  def self.admin_guest
+    find_or_create_by!(email: 'admin_guest@example.com') do |user|
+      user.name = 'AdminGuest'
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -5,3 +5,4 @@
 <p><%= link_to I18n.t('views.messages.new_registration'), new_user_registration_path %></p>
 <p><%= link_to I18n.t('views.messages.login'), new_user_session_path %></p>
 <p><%= link_to I18n.t('views.messages.guest_sign_in'), users_guest_sign_in_path, method: :post %></p>
+<p><%= link_to I18n.t('views.messages.admin_guest_sign_in'), users_admin_guest_sign_in_path, method: :post %></p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -248,3 +248,5 @@ ja:
       go_top_index: 'トップページへ戻る'
       guest_sign_in: 'ゲストログイン（閲覧用）'
       logged_in_as_guest_user: 'ゲストユーザーとしてログインしました。'
+      admin_guest_sign_in: '管理者ゲストログイン（閲覧用）'
+      logged_in_as_admin_guest_user: '管理者ゲストユーザーとしてログインしました。'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   }
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
+    post 'users/admin_guest_sign_in', to: 'users/sessions#admin_guest_sign_in'
   end
   resources :users
   namespace :admin do


### PR DESCRIPTION
- ルーターに管理者ゲストログインのための新アクションのルーティングを記述
- devise セッションコントローラーに管理者ゲストログインのアクションを記述
- 管理者ゲストユーザーかどうかの判別を行うメソッドをユーザーモデルに記述
- トップビュー　インデックスページに管理者ゲストログインリンクを設置
- トップページの管理者ゲストログインリンクの文言を国際化